### PR TITLE
Fix PollResult voted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Add CORS support
+### Fixed
+- Fix PollResult voted bug
 
 ## [1.8.2] - 2024-07-15
 ### Fixed 

--- a/core/model/poll.go
+++ b/core/model/poll.go
@@ -185,7 +185,7 @@ func (poll *Poll) ToPollResult(currentUserID string) PollResult {
 		for _, e := range poll.Responses {
 			votersMap[e.UserID] = true
 
-			userVoted := poll.UserID == currentUserID
+			userVoted := e.UserID == currentUserID
 
 			for _, a := range e.Answer {
 				if a >= 0 && a < count {


### PR DESCRIPTION
## Description
This PR fixes an issue where the `voted` field in `PollResult` was not being populated due to the wrong user ID being used to determine whether the user calling `GET /polls` has voted in each poll.
