### PR TITLE
Use group polls notification topic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix PollResult voted bug
 - Move GET request bodies to query for web
 - Fix poll DateUpdated set to time zero value on creation
+- Use group polls notification topic
 
 ## [1.10.0] - 2025-05-15
 ### Fixed

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
 # Default assignment
-*   @mdryankov

--- a/core/services.go
+++ b/core/services.go
@@ -183,14 +183,15 @@ func (app *Application) endPoll(user *model.User, pollID string) error {
 }
 
 func (app *Application) notifyNotificationsBBForPoll(user *model.User, poll *model.Poll, topic string, operation string, message string) {
-	subject := "Illinois"
+	subject := "Poll"
 	if poll.GroupID != nil {
 
 		group, _ := app.groups.GetGroupDetails(user.Token, *poll.GroupID)
 		if group != nil {
-			subject = fmt.Sprintf("Group - %s", group.Title)
+			subject = fmt.Sprintf("Group Poll - %s", group.Title)
 		}
 
+		topic = fmt.Sprintf("group.%s", topic)
 		app.groups.SendGroupNotification(*poll.GroupID, model.GroupNotification{
 			Members: poll.ToMembersList.ToNotificationRecipients(),
 			Sender: &model.Sender{


### PR DESCRIPTION
## Description
This PR changes the notification topic used for group polls to "group.polls". It also changes the notification subject from "Illinois" to "Poll"

[comment]: # (This project only accepts pull requests related to open issues.)
[comment]: # (If suggesting a new feature or change, please discuss it in an issue first.)
[comment]: # (If fixing a bug, there should be an issue describing it with steps to reproduce.)

## Review Time Estimate
_Please give your idea of how soon this pull request needs to be reviewed by selecting one of the options below. This can be based on the criticality of the issue at hand and/or other relevant factors._

[comment]: # (To select an option, please put an 'x' in the applicable box.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [x] Immediately
- [ ] Within a week
- [ ] When possible

## Type of changes
_Please select a relevant option:_

[comment]: # (To select an option, please put an 'x' in the applicable box.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Other (any another change that does not fall in one of the above categories.)

## Checklist:
_Please select all applicable options:_

[comment]: # (To select your options, please put an 'x' in the all boxes that apply.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [x] I have signed the Rokwire Contributor License Agreement ([CLA](https://rokwire.org/rokwire_cla)). (_Any contributor who is not an employee of the University of Illinois whose official duties include contributing to the Rokwire software, or who is not paid by the Rokwire project, needs to sign the CLA before their contribution can be accepted._)
- [x] I have updated the [CHANGELOG](../CHANGELOG.md).
- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] My change requires updating the documentation.
- [ ] I have made necessary changes to the documentation.
- [ ] I have added tests related to my changes.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.

---

[comment]: # (Template credit: This pull request template is based on Embedded Artistry {https://github.com/embeddedartistry/templates/blob/master/.github/PULL_REQUEST_TEMPLATE.md}, Clowder {https://github.com/clowder-framework/clowder/blob/develop/.github/PULL_REQUEST_TEMPLATE.md}, and TalAter {https://github.com/TalAter/open-source-templates} templates.)